### PR TITLE
fix: index betti_numbers by ascending cohomological degree

### DIFF
--- a/src/Hodge.jl
+++ b/src/Hodge.jl
@@ -413,7 +413,8 @@ Compute the Betti numbers of the moduli space `M`.
 
 # Output
 
-- a list of Betti numbers of the moduli space.
+- a list of Betti numbers of the moduli space, indexed by cohomological
+  degree ``0, \\dots, 2\\dim M``.
 
 # Examples
 
@@ -457,14 +458,11 @@ function betti_numbers(M::QuiverModuliSpace)
 
   N = dimension(M)
   P = poincare_polynomial(M)
-  coeff = Int.(numerator.(Singular.coefficients(P)))
-  betti = reduce(vcat, [c, 0] for c in coeff[1:(end - 1)])
-  push!(betti, coeff[end])
-
-  # if the polynomial did not have degree = N,
-  # we add zero coefficients
-  if length(betti) < 2 * N + 1
-    betti = vcat(betti, zeros(2 * N + 1 - length(betti)))
+  # entry 2k + 1 is the coefficient of L^k in P, i.e., the Betti number
+  # in cohomological degree 2k; all odd Betti numbers vanish
+  betti = zeros(Int, 2 * N + 1)
+  for (c, e) in zip(Singular.coefficients(P), Singular.exponent_vectors(P))
+    betti[2 * e[1] + 1] = Int(numerator(c))
   end
   return betti
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,3 +140,20 @@ end;
   # ξ5 = (e_K^2, e_Kbar^2): two vertices, a 2-cycle, local dimension (2, 2)
   @test fingerprint(Dict(eK => [2], eKb => [2])) == ([2, 2], [0, 0], [0, 0, 1, 1], true)
 end;
+
+@testset "Betti numbers" begin
+  # betti_numbers is the coefficient vector of the Poincaré polynomial, indexed
+  # by ascending cohomological degree, always a Vector{Int} (regression: for
+  # non-palindromic Poincaré polynomials, which occur for quivers with oriented
+  # cycles, the coefficients were listed by descending degree and the padding to
+  # length 2 dim + 1 used Float64 zeros; a monomial Poincaré polynomial crashed).
+  # The round-trip quiver with d = (1, 1) has moduli space A^1, so P = L.
+  Q = Quiver([0 1; 1 0])
+  M = QuiverModuliSpace(Q, [1, 1], [1, -1])
+  @test betti_numbers(M) isa Vector{Int}
+  @test betti_numbers(M) == [0, 0, 1]
+
+  # the smooth projective (palindromic) case is unchanged: our favourite 6-fold
+  M = QuiverModuliSpace(kronecker_quiver(3), [2, 3])
+  @test betti_numbers(M) == [1, 0, 1, 0, 3, 0, 3, 0, 3, 0, 1, 0, 1]
+end;


### PR DESCRIPTION
## Problem

`betti_numbers(M)` misbehaves whenever the Poincaré polynomial is not palindromic, which happens for quivers with oriented cycles (the moduli space is smooth but not projective, so Poincaré duality does not force symmetry). Three distinct defects:

1. **Wrong ordering.** `Singular.coefficients(P)` returns coefficients leading-term-first, and the old code interleaved them with zeros in that order. For a non-palindromic `P` this lists the Betti numbers by *descending* cohomological degree, so `betti[i]` is not `b_{2(i-1)}`.
2. **`Float64` output.** The zero-padding to length `2 dim + 1` used `zeros(...)`, whose default eltype is `Float64`, promoting the whole `Vector{Int}` to `Vector{Float64}` (e.g. `[1.0, 0.0, ...]`). This padding branch only fires when `deg P < 2 dim`, which never happens in the palindromic examples the package usually runs on.
3. **Crash on a monomial `P`.** When `P` is a single term (e.g. the round-trip quiver `1 ⇄ 2` with `d = (1,1)`, whose moduli space is `A^1` with `P = L`), `coeff[1:(end-1)]` is empty and `reduce(vcat, ...)` throws.

## Fix

Build a `zeros(Int, 2 dim + 1)` vector and place each coefficient at its true degree via `zip(Singular.coefficients(P), Singular.exponent_vectors(P))` (the same idiom already used in `Chow.jl`). This is integer-valued, ascending-degree-indexed, and correct for a monomial or any gapped polynomial.

## Test

Adds a "Betti numbers" testset: the round-trip quiver (`A^1`, expects `[0, 0, 1]` as a `Vector{Int}`, which the old code failed on all three counts) plus the palindromic 6-fold as a no-regression guard. The existing doctests are palindromic and remain valid.