### PR TITLE
fix: correct sign of stack motive and Poincaré polynomial

### DIFF
--- a/src/Hodge.jl
+++ b/src/Hodge.jl
@@ -507,7 +507,9 @@ function poincare_polynomial(M::QuiverModuliSpace)
 
   m = motive(M.Q, M.d, M.theta, M.denom)
   v = Singular.transcendence_basis(Singular.parent(m))[1]
-  P = (1 - v) * m
+  # the stack of stable representations is a G_m-gerbe over the moduli space, so
+  # [M] = (L - 1) * [stack motive]
+  P = (v - 1) * m
 
   denominator(P) != 1 && throw(DomainError("must be a polynomial"))
   # returns a polynomial object instead of a FunctionField element.
@@ -549,7 +551,7 @@ Compute the motive of the moduli stack of `theta`-semistable representations.
 julia> Q = kronecker_quiver(3);
 
 julia> motive(Q, [2, 3])
-(-L^6 - L^5 - 3*L^4 - 3*L^3 - 3*L^2 - L - 1)//(L - 1)
+(L^6 + L^5 + 3*L^4 + 3*L^3 + 3*L^2 + L + 1)//(L - 1)
 ```
 """
 function motive(
@@ -590,5 +592,7 @@ function motive(
   y[end] = 1
   y = coerce_vector(y)
 
-  return solve(T, y)[1]
+  # the HN recursion produces the negative of the honest stack motive; negate so
+  # this branch agrees with the trivial-stability branch above (see issue #36)
+  return -solve(T, y)[1]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -157,3 +157,26 @@ end;
   M = QuiverModuliSpace(kronecker_quiver(3), [2, 3])
   @test betti_numbers(M) == [1, 0, 1, 0, 3, 0, 3, 0, 3, 0, 1, 0, 1]
 end;
+
+@testset "motive/poincare sign" begin
+  # The two branches of motive must agree in sign: the HN recursion returns the
+  # honest stack motive [M]/(L-1), and the trivial-stability branch returns the
+  # full-stack motive; poincare_polynomial recovers [M] = (L-1)*[stack motive].
+  # (regression #36: for a quiver with loops the trivial branch was consumed with
+  # the opposite sign, giving e.g. P = -L for the affine line.)
+  # poincare_polynomial returns an spoly and motive an n_transExt, so compare the
+  # rendered strings, as the doctests do.
+
+  # loop_quiver(g), d = [1]: moduli space is A^g, so P = L^g and motive = L^g/(L-1)
+  for (g, p) in ((1, "L"), (2, "L^2"), (3, "L^3"))
+    M = QuiverModuliSpace(loop_quiver(g), [1], [0])
+    @test string(poincare_polynomial(M)) == p
+    @test string(motive(QuiverModuliStack(loop_quiver(g), [1], [0], "stable"))) ==
+      "$p//(L - 1)"
+  end
+
+  # recursion path is unchanged: the space motive of the 6-fold stays positive
+  M = QuiverModuliSpace(kronecker_quiver(3), [2, 3])
+  @test string(poincare_polynomial(M)) ==
+    "L^6 + L^5 + 3*L^4 + 3*L^3 + 3*L^2 + L + 1"
+end;


### PR DESCRIPTION
Closes #36. Stacked on #35 (`fix/betti-numbers`); the `runtests.jl` additions sit next to that PR's testset, so this targets `fix/betti-numbers` and should be retargeted to `main` once #35 merges.

## Problem

For a quiver with loops, `poincare_polynomial` (and hence `betti_numbers`) returned a negated result, e.g. `loop_quiver(1)` with `d = [1]` (moduli space `A^1`) gave `P = -L` instead of `L`.

## Root cause

`motive` uses two branches with **opposite sign conventions**:

- The **trivial-stability branch** returns the honest stack motive, `L^{-<d,d>} / prod_i prod_k (1 - L^{-k})`. This is correct.
- The **Harder-Narasimhan recursion branch** returns the *negative* of the honest stack motive: verified uniformly as `-[M]/(L-1)` across Kronecker quivers (2/3/4 arrows, several dimension vectors) and a three-vertex quiver.

`poincare_polynomial` then multiplied by `(1 - L)`, which is `-(L - 1)`. Against the recursion branch the two negatives cancel and the result is correct; against the trivial branch there is nothing to cancel, so the sign flips. The trivial branch is reached (past the coprimality guard) exactly for coordinate dimension vectors, i.e. single-vertex/looped quivers.

The blessed doctest `motive(Q, [2,3]) == (-L^6 - ... - 1)//(L - 1)` had enshrined the wrong-signed recursion output.

## Fix

- Negate the recursion branch output so both branches of `motive` return the honest stack motive. This also fixes `motive(::QuiverModuliStack)`, which previously returned negated values.
- `poincare_polynomial` now uses the honest `G_m`-gerbe relation `[M] = (L - 1) * [stack motive]`, i.e. the `(v - 1)` factor.
- Update the `motive` doctest to the now-positive value.

Because both the recursion sign and the `poincare_polynomial` factor flip together, every recursion-path output is unchanged (all existing `poincare_polynomial`/`betti_numbers`/Hodge doctests still pass). Only the direct trivial-branch consumers change, and they change from wrong to right.

## Test

Adds a "motive/poincare sign" testset: `loop_quiver(g)` with `d = [1]` must give `P = L^g` and `motive = L^g//(L - 1)` for `g = 1, 2, 3`, plus a guard pinning the 6-fold's recursion-path Poincaré polynomial. Full suite (doctests + testsets) is green.