### PR TITLE
fix: correct sign of stack motive and Poincaré polynomial

### DIFF
--- a/src/Hodge.jl
+++ b/src/Hodge.jl
@@ -507,7 +507,9 @@ function poincare_polynomial(M::QuiverModuliSpace)
 
   m = motive(M.Q, M.d, M.theta, M.denom)
   v = Singular.transcendence_basis(Singular.parent(m))[1]
-  P = (1 - v) * m
+  # the stack of stable representations is a G_m-gerbe over the moduli space, so
+  # [M] = (L - 1) * [stack motive]
+  P = (v - 1) * m
 
   denominator(P) != 1 && throw(DomainError("must be a polynomial"))
   # returns a polynomial object instead of a FunctionField element.
@@ -549,7 +551,7 @@ Compute the motive of the moduli stack of `theta`-semistable representations.
 julia> Q = kronecker_quiver(3);
 
 julia> motive(Q, [2, 3])
-(-L^6 - L^5 - 3*L^4 - 3*L^3 - 3*L^2 - L - 1)//(L - 1)
+(L^6 + L^5 + 3*L^4 + 3*L^3 + 3*L^2 + L + 1)//(L - 1)
 ```
 """
 function motive(
@@ -590,5 +592,7 @@ function motive(
   y[end] = 1
   y = coerce_vector(y)
 
-  return solve(T, y)[1]
+  # the HN recursion produces the negative of the honest stack motive; negate so
+  # this branch agrees with the trivial-stability branch above (see issue #36)
+  return -solve(T, y)[1]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -157,3 +157,26 @@ end;
   M = QuiverModuliSpace(kronecker_quiver(3), [2, 3])
   @test betti_numbers(M) == [1, 0, 1, 0, 3, 0, 3, 0, 3, 0, 1, 0, 1]
 end;
+
+@testset "motive/poincare sign" begin
+  # The two branches of motive must agree in sign: the HN recursion returns the
+  # honest stack motive [M]/(L-1), and the trivial-stability branch returns the
+  # full-stack motive; poincare_polynomial recovers [M] = (L-1)*[stack motive].
+  # (regression #36: for a quiver with loops the trivial branch was consumed with
+  # the opposite sign, giving e.g. P = -L for the affine line.)
+  # poincare_polynomial returns an spoly and motive an n_transExt, so compare the
+  # rendered strings, as the doctests do.
+
+  # loop_quiver(g), d = [1]: moduli space is A^g, so P = L^g and motive = L^g/(L-1)
+  for (g, p) in ((1, "L"), (2, "L^2"), (3, "L^3"))
+    M = QuiverModuliSpace(loop_quiver(g), [1], [0])
+    @test string(poincare_polynomial(M)) == p
+    @test string(motive(QuiverModuliStack(loop_quiver(g), [1], [0], "stable"))) ==
+      "$p//(L - 1)"
+  end
+
+  # recursion path is unchanged: the space motive of the 6-fold stays positive
+  M = QuiverModuliSpace(kronecker_quiver(3), [2, 3])
+  @test string(poincare_polynomial(M)) ==
+    "L^6 + L^5 + 3*L^4 + 3*L^3 + 3*L^2 + L + 1"
+end;


### PR DESCRIPTION
The Harder-Narasimhan recursion returned the negative of the honest stack motive, and poincare_polynomial compensated with a (1 - L) factor. The two cancelled for the recursion path but not for the trivial-stability branch, so quivers with loops gave a negated Poincaré polynomial (P = -L for the affine line). Negate the recursion output so both branches of motive agree, and use the honest gerbe relation [M] = (L - 1) * [stack motive].