### PR TITLE
feat: draw quivers with GraphViz via to_dot and a package extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,14 +16,22 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [weakdeps]
+GraphViz = "f526b714-d49f-11e8-06ff-31ed36ee7ee0"
+# Not imported directly; listed only to pin its version. The resolver otherwise
+# defaults to an older Graphviz_jll build whose `libgvc` binding is undefined,
+# which crashes GraphViz on load. See the GraphViz compat note below.
+Graphviz_jll = "3c863552-8265-54e4-a6dc-903eb78fde85"
 Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 
 [extensions]
+QuiverToolsGraphVizExt = "GraphViz"
 QuiverToolsOscarExt = "Oscar"
 
 [compat]
 Combinatorics = "1"
 Documenter = "1"
+GraphViz = "0.2"
+Graphviz_jll = "2.50"
 IterTools = "1"
 LinearAlgebraX = "0.2.10"
 Memoization = "0.2.2"

--- a/docs/src/methods/quivers.md
+++ b/docs/src/methods/quivers.md
@@ -26,3 +26,16 @@ is_sink
 is_source
 underlying_graph
 ```
+
+## Visualization
+
+`to_dot` renders a quiver as a [Graphviz](https://graphviz.org) DOT string,
+drawing parallel arrows and loops as themselves. Running `using GraphViz`
+alongside QuiverTools additionally makes a `Quiver` display as an SVG drawing in
+notebooks (Pluto, IJulia) and VS Code; from the REPL, `draw` opens that drawing
+in the system viewer.
+
+```@docs
+to_dot
+draw
+```

--- a/ext/QuiverToolsGraphVizExt.jl
+++ b/ext/QuiverToolsGraphVizExt.jl
@@ -1,0 +1,31 @@
+module QuiverToolsGraphVizExt
+
+# Renders a quiver as SVG by handing its DOT description (see `to_dot` in
+# src/Quivers.jl) to Graphviz. Loaded automatically when a user runs
+# `using GraphViz` alongside QuiverTools; from then on a `Quiver` shows as a
+# drawing in notebooks (Pluto, IJulia) and VS Code, and `draw` opens it in the
+# system viewer from the REPL.
+
+using QuiverTools: Quiver, to_dot
+using GraphViz: GraphViz
+import QuiverTools: draw
+
+Base.show(io::IO, mime::MIME"image/svg+xml", Q::Quiver) =
+  show(io, mime, GraphViz.Graph(to_dot(Q)))
+
+function draw(Q::Quiver)
+  path = tempname() * ".svg"
+  open(path, "w") do io
+    show(io, MIME("image/svg+xml"), Q)
+  end
+  if Sys.isapple()
+    run(`open $path`)
+  elseif Sys.iswindows()
+    run(`cmd /c start "" $path`)
+  else
+    run(`xdg-open $path`)
+  end
+  return path
+end
+
+end

--- a/src/QuiverTools.jl
+++ b/src/QuiverTools.jl
@@ -40,7 +40,7 @@ export Quiver, HNType, LunaType, QuiverModuli, QuiverModuliSpace, QuiverModuliSt
 # Quivers
 export n_vertices,
   n_arrows, arrows, indegree, outdegree, is_acyclic, is_connected, is_sink, is_source,
-  underlying_graph, first_hochschild_cohomology
+  underlying_graph, first_hochschild_cohomology, to_dot, draw
 
 # Constructors
 export kronecker_quiver, loop_quiver, jordan_quiver, subspace_quiver, star_quiver,

--- a/src/Quivers.jl
+++ b/src/Quivers.jl
@@ -210,6 +210,91 @@ function arrows(Q::Quiver)
   )
 end
 
+# Compass ports used to spread self-loops around a vertex: Graphviz stacks
+# multiple loops on the same side otherwise, which reads as a single blob.
+const _LOOP_PORTS = ("n", "s", "e", "w", "ne", "sw", "se", "nw")
+
+"""
+    to_dot(Q::Quiver)
+
+Return a Graphviz DOT description of `Q` as a `String`.
+
+Every arrow becomes its own `i -> j` line, so parallel arrows and loops (a
+quiver's defining features) are drawn as themselves; self-loops are distributed
+around their vertex with compass ports. Isolated vertices are emitted explicitly.
+
+Feed the result to Graphviz, e.g. `using GraphViz; GraphViz.Graph(to_dot(Q))`,
+which also makes `Q` render as SVG in notebooks and VS Code once GraphViz is
+loaded. With the DOT string in hand you can equally pipe it to the `dot`
+command line tool.
+
+# Examples
+
+```jldoctest
+julia> print(to_dot(kronecker_quiver(2)))
+digraph {
+  label="2-Kronecker quiver";
+  node [shape=circle];
+  1;
+  2;
+  1 -> 2;
+  1 -> 2;
+}
+
+julia> print(to_dot(loop_quiver(2)))
+digraph {
+  label="2-loop quiver";
+  node [shape=circle];
+  1;
+  1:n -> 1:n;
+  1:s -> 1:s;
+}
+```
+"""
+function to_dot(Q::Quiver)
+  n = n_vertices(Q)
+  io = IOBuffer()
+  println(io, "digraph {")
+  isempty(Q.name) || println(io, "  label=\"", Q.name, "\";")
+  println(io, "  node [shape=circle];")
+  for i in 1:n
+    println(io, "  ", i, ";")
+  end
+  for i in 1:n, j in 1:n
+    if i == j
+      for t in 1:Q.adjacency[i, i]
+        p = _LOOP_PORTS[mod1(t, length(_LOOP_PORTS))]
+        println(io, "  ", i, ":", p, " -> ", i, ":", p, ";")
+      end
+    else
+      for _ in 1:Q.adjacency[i, j]
+        println(io, "  ", i, " -> ", j, ";")
+      end
+    end
+  end
+  println(io, "}")
+  return String(take!(io))
+end
+
+"""
+    draw(Q::Quiver)
+
+Render `Q` with Graphviz and open the drawing in the system's default viewer
+(browser or image application). Writes a temporary SVG file and returns its path.
+
+Requires GraphViz: run `using GraphViz` to enable this method. In notebooks and
+VS Code you do not need `draw`, evaluating `Q` displays the drawing inline.
+
+# Example
+
+```julia
+using QuiverTools, GraphViz
+
+draw(loop_quiver(2))   # opens the drawing; returns the temporary file path
+```
+"""
+function draw end
+
 """
     first_hochschild_cohomology(Q::Quiver)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,3 +180,24 @@ end;
   @test string(poincare_polynomial(M)) ==
     "L^6 + L^5 + 3*L^4 + 3*L^3 + 3*L^2 + L + 1"
 end;
+
+@testset "to_dot" begin
+  # the exact string for the happy path is locked by the doctests; here we check
+  # arrow bookkeeping and the edge cases they don't show.
+
+  # one `->` line per arrow, loops included
+  count_arrows(Q) = count(l -> occursin("->", l), split(to_dot(Q), '\n'))
+  @test count_arrows(kronecker_quiver(3)) == n_arrows(kronecker_quiver(3)) == 3
+  @test count_arrows(three_vertex_quiver(1, 2, 3)) ==
+    n_arrows(three_vertex_quiver(1, 2, 3)) == 6
+  @test count_arrows(loop_quiver(4)) == n_arrows(loop_quiver(4)) == 4
+
+  # self-loops are spread with compass ports rather than stacked
+  @test occursin("1:n -> 1:n", to_dot(loop_quiver(2)))
+  @test occursin("1:s -> 1:s", to_dot(loop_quiver(2)))
+
+  # a quiver with no arrows still declares its (isolated) vertices, no crash
+  isolated = to_dot(Quiver([0 0; 0 0]))
+  @test count(l -> occursin("->", l), split(isolated, '\n')) == 0
+  @test occursin("\n  1;\n", isolated) && occursin("\n  2;\n", isolated)
+end;


### PR DESCRIPTION
## What

Adds quiver visualization to QuiverTools. Parallel arrows and loops (a quiver's defining features) are drawn as themselves rather than collapsed to a single labelled edge.

## API

- `to_dot(Q)` returns a [Graphviz](https://graphviz.org) DOT string. It is dependency-free and lives in the core package: one `i -> j` line per arrow, self-loops spread around their vertex with compass ports, and isolated vertices emitted explicitly.
- `using GraphViz` activates a package extension that makes a `Quiver` display as an SVG drawing inline in notebooks (Pluto, IJulia) and VS Code.
- `draw(Q)`, from the REPL, renders the quiver and opens it in the system's default viewer, returning the temporary file path.

## Design

- The extension (`ext/QuiverToolsGraphVizExt.jl`) mirrors the existing Oscar extension. `GraphViz` is a weak dependency, so a plain `using QuiverTools` never loads a graphics binary; `to_dot` is always available, while the SVG `show` method and `draw` activate only once GraphViz is loaded.
- `Graphviz_jll` is pinned to `>= 2.50`. Without the pin the resolver can select an older build whose `libgvc` binding is undefined, which crashes `using GraphViz` with a cryptic error.

## Tests and docs

- A `to_dot` testset covers arrow bookkeeping, port-spaced loops, and the no-arrow (isolated vertices) edge case; the exact output is locked by doctests.
- Docstrings for `to_dot` and `draw` are added to the Quivers manual page.
